### PR TITLE
Fix Missile Controllers

### DIFF
--- a/ExampleScripts/NaiveMissileGuidance.cs
+++ b/ExampleScripts/NaiveMissileGuidance.cs
@@ -10,11 +10,15 @@ public class NaiveMissileGuidance : IFtDSharp
     public void Update(float deltaTime)
     {
         var target = AI.HighestPriorityMainframe.PrimaryTarget;
-        foreach (var missileController in Weapons.MissileControllers)
-            missileController.Fire();
+
 
         if (target == null) foreach (var missile in Guidance.Missiles) missile.Detonate();
+        else
+        {
+            foreach (var missileController in Weapons.MissileControllers) missileController.Fire();
 
-        else foreach (var missile in Guidance.Missiles) missile.AimAt(target.Position);
+            foreach (var missile in Guidance.Missiles) missile.AimAt(target.Position);
+        }
+
     }
 }

--- a/FtDSharp.Main/Facades/WeaponFacade.cs
+++ b/FtDSharp.Main/Facades/WeaponFacade.cs
@@ -69,7 +69,7 @@ namespace FtDSharp.Facades
         public bool OnTarget => _lastResult?.IsOnTarget ?? false;
         public bool CanAim => _lastResult?.CanAim ?? false;
         public bool IsBlocked => _lastResult?.AimResult.IsBlocked ?? false;
-        public bool CanFire => _lastResult?.CanFire ?? false;
+        public virtual bool CanFire => _lastResult?.CanFire ?? false;
         public float FlightTime => _lastResult?.FlightTime ?? 0f;
         public Vector3 AimPoint => _lastResult?.AimPoint ?? Vector3.zero;
         public bool BlockedByTerrain => _lastResult?.IsTerrainBlocking ?? false;

--- a/FtDSharp.Main/Facades/Weapons/MissileControlFacade.Weapon.cs
+++ b/FtDSharp.Main/Facades/Weapons/MissileControlFacade.Weapon.cs
@@ -2,6 +2,15 @@ namespace FtDSharp.Facades
 {
     internal partial class MissileControlFacade : IMissileController
     {
+        public override bool CanFire => IsReady;
+
+        public override bool Fire()
+        {
+            var forward = Weapon.GameWorldRotation * UnityEngine.Vector3.forward;
+            SetAimState(AimAtDirectionInternal(forward));
+            return FireInternal();
+        }
+
         public int LoadedMissileCount
         {
             get

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "FtDSharp",
-  "version": "0.2.0-alpha",
+  "version": "0.2.3",
   "gameversion": "4.3.0",
   "conflicts": [],
   "depends": [],

--- a/release.sh
+++ b/release.sh
@@ -144,12 +144,12 @@ chmod +x dist/FtDSharp/clone-source.sh
 echo "[5/5] Creating release archive..."
 cd dist
 if command -v zip &> /dev/null; then
-  zip -r "../FtDSharp-v$VERSION.zip" FtDSharp
-  echo "  ✓ Created FtDSharp-v$VERSION.zip (using zip)"
+  zip -r "../FtDSharp.zip" FtDSharp
+  echo "  ✓ Created FtDSharp.zip (using zip)"
 else
   # Windows powershell's Compress-Archive
-  powershell -Command "Compress-Archive -Path 'FtDSharp\*' -DestinationPath \"../FtDSharp-v$VERSION.zip\" -Force"
-  echo "  ✓ Created FtDSharp-v$VERSION.zip (using Compress-Archive)"
+  powershell -Command "Compress-Archive -Path 'FtDSharp\*' -DestinationPath \"../FtDSharp.zip\" -Force"
+  echo "  ✓ Created FtDSharp.zip (using Compress-Archive)"
 fi
 cd ..
 


### PR DESCRIPTION
fix missile controller Fire() method and correct CanFire property

Cause: missile controllers expect to be aimed first despite not being able to gimbal

Fixes #25 